### PR TITLE
Fix install one-liner and default to app.stemplin.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bash install.sh
 **One-liner (downloads from GitHub):**
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/rubynor/stemplin-cli/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/rubynor/stemplin-cli/master/install.sh | bash
 ```
 
 The installer places:
@@ -34,7 +34,7 @@ export PATH="$HOME/bin:$PATH"
 Set these environment variables (or put them in `~/.stemplinrc`):
 
 ```bash
-export STEMPLIN_URL="https://stemplin.com"    # or http://localhost:3000
+export STEMPLIN_URL="https://app.stemplin.com" # or http://localhost:3000
 export STEMPLIN_API_TOKEN="your-token-here"
 export STEMPLIN_ORG_ID=""                       # optional
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_RAW="https://raw.githubusercontent.com/rubynor/stemplin-cli/main"
+REPO_RAW="https://raw.githubusercontent.com/rubynor/stemplin-cli/master"
 
 BIN_DIR="$HOME/bin"
 SKILL_DIR="$HOME/.claude/skills"
@@ -51,11 +51,12 @@ ok "Bash completions installed to $COMPLETION_DIR/stemplin"
 # 4. Config file
 if [[ ! -f "$RC_FILE" ]]; then
   echo ""
-  read -rp "Create ~/.stemplinrc with your API config? [Y/n] " answer
+  read -rp "Create ~/.stemplinrc with your API config? [Y/n] " answer </dev/tty
   if [[ "${answer:-Y}" =~ ^[Yy]$ ]]; then
-    read -rp "  STEMPLIN_URL (e.g. https://stemplin.com): " url
-    read -rp "  STEMPLIN_API_TOKEN: " token
-    read -rp "  STEMPLIN_ORG_ID (optional, press Enter to skip): " org_id
+    read -rp "  STEMPLIN_URL [https://app.stemplin.com]: " url </dev/tty
+    url="${url:-https://app.stemplin.com}"
+    read -rp "  STEMPLIN_API_TOKEN: " token </dev/tty
+    read -rp "  STEMPLIN_ORG_ID (optional, press Enter to skip): " org_id </dev/tty
 
     cat > "$RC_FILE" <<EOF
 export STEMPLIN_URL="${url}"


### PR DESCRIPTION
## Summary
- Fix 404 on `curl | bash` one-liner by changing raw GitHub URL branch from `/main` to `/master`
- Read from `/dev/tty` so interactive prompts work when stdin is piped
- Default `STEMPLIN_URL` to `https://app.stemplin.com` when user presses Enter
- Update README examples to match

## Test plan
- [ ] Run `curl -sSL https://raw.githubusercontent.com/rubynor/stemplin-cli/master/install.sh | bash` and verify it downloads and prompts work
- [ ] Verify pressing Enter at the URL prompt defaults to `https://app.stemplin.com`
- [ ] Run `bash install.sh` locally and confirm prompts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)