### PR TITLE
Add stemplin update command

### DIFF
--- a/bin/stemplin
+++ b/bin/stemplin
@@ -111,6 +111,29 @@ _minutes_to_hm() {
 
 _today() { date +%Y-%m-%d; }
 
+_build_report_qs() {
+  local from="" to="" clients="" projects="" users="" tasks=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --from)     from="$2"; shift 2 ;;
+      --to)       to="$2"; shift 2 ;;
+      --clients)  clients="$2"; shift 2 ;;
+      --projects) projects="$2"; shift 2 ;;
+      --users)    users="$2"; shift 2 ;;
+      --tasks)    tasks="$2"; shift 2 ;;
+      *) die "Unknown flag: $1" ;;
+    esac
+  done
+  _REPORT_QS=""
+  [[ -n "$from" ]]     && _REPORT_QS="${_REPORT_QS}&start_date=${from}"
+  [[ -n "$to" ]]       && _REPORT_QS="${_REPORT_QS}&end_date=${to}"
+  [[ -n "$clients" ]]  && _REPORT_QS="${_REPORT_QS}&client_ids=${clients}"
+  [[ -n "$projects" ]] && _REPORT_QS="${_REPORT_QS}&project_ids=${projects}"
+  [[ -n "$users" ]]    && _REPORT_QS="${_REPORT_QS}&user_ids=${users}"
+  [[ -n "$tasks" ]]    && _REPORT_QS="${_REPORT_QS}&task_ids=${tasks}"
+  _REPORT_QS="?${_REPORT_QS#&}"
+}
+
 # ---------------------------------------------------------------------------
 # me
 # ---------------------------------------------------------------------------
@@ -454,30 +477,9 @@ cmd_reports() {
   local action="${1:-show}"; shift || true
   case "$action" in
     show)
-      local from="" to="" clients="" projects="" users="" tasks=""
-      while [[ $# -gt 0 ]]; do
-        case "$1" in
-          --from)     from="$2"; shift 2 ;;
-          --to)       to="$2"; shift 2 ;;
-          --clients)  clients="$2"; shift 2 ;;
-          --projects) projects="$2"; shift 2 ;;
-          --users)    users="$2"; shift 2 ;;
-          --tasks)    tasks="$2"; shift 2 ;;
-          *) die "Unknown flag: $1" ;;
-        esac
-      done
-
-      local qs=""
-      [[ -n "$from" ]]     && qs="${qs}&start_date=${from}"
-      [[ -n "$to" ]]       && qs="${qs}&end_date=${to}"
-      [[ -n "$clients" ]]  && qs="${qs}&client_ids=${clients}"
-      [[ -n "$projects" ]] && qs="${qs}&project_ids=${projects}"
-      [[ -n "$users" ]]    && qs="${qs}&user_ids=${users}"
-      [[ -n "$tasks" ]]    && qs="${qs}&task_ids=${tasks}"
-      qs="?${qs#&}"
-
+      _build_report_qs "$@"
       local result
-      result=$(_api GET "/reports${qs}")
+      result=$(_api GET "/reports${_REPORT_QS}")
 
       if $RAW; then
         echo "$result"
@@ -507,7 +509,33 @@ cmd_reports() {
           ]) | @tsv' | column -t -s $'\t'
       fi
       ;;
-    *) die "Unknown reports action: $action. Try: show" ;;
+    detailed)
+      _build_report_qs "$@"
+      local result
+      result=$(_api GET "/reports/detailed${_REPORT_QS}")
+
+      if $RAW; then
+        echo "$result"
+      else
+        local total_min total_billable
+        total_min=$(echo "$result" | jq -r '.total_minutes')
+        total_billable=$(echo "$result" | jq -r '.total_billable_minutes // 0')
+        echo "Total: $(_minutes_to_hm "$total_min")  Billable: $(_minutes_to_hm "$total_billable")"
+        echo ""
+        echo "$result" | jq -r '
+          ["DATE", "CLIENT", "PROJECT", "TASK", "PERSON", "HOURS", "NOTES"],
+          (.dates[] | .date as $date | .time_regs[] | [
+            $date,
+            .client_name // "-",
+            .project_name // "-",
+            .task_name // "-",
+            .user_name // "-",
+            ((.minutes / 60 * 100 | round) / 100 | tostring) + "h",
+            (.notes // "-" | if length > 30 then .[:30] + "..." else . end)
+          ]) | @tsv' | column -t -s $'\t'
+      fi
+      ;;
+    *) die "Unknown reports action: $action. Try: show, detailed" ;;
   esac
 }
 
@@ -530,6 +558,64 @@ cmd_token() {
       ;;
     *) die "Usage: stemplin token regenerate" ;;
   esac
+}
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+REPO_RAW="https://raw.githubusercontent.com/rubynor/stemplin-cli/main"
+
+cmd_update() {
+  local check_only=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --check) check_only=true; shift ;;
+      *) die "Unknown flag: $1" ;;
+    esac
+  done
+
+  local tmp
+  tmp=$(mktemp) || die "Failed to create temp file"
+  trap 'rm -f "$tmp"' RETURN
+
+  curl -sSL "$REPO_RAW/bin/stemplin" -o "$tmp" || die "Failed to download latest version"
+
+  local remote_version
+  remote_version=$(grep -m1 '^VERSION=' "$tmp" | sed 's/VERSION="//;s/"//') || die "Failed to parse remote version"
+  [[ -n "$remote_version" ]] || die "Failed to parse remote version"
+
+  if [[ "$remote_version" == "$VERSION" ]]; then
+    echo "Already up to date (v${VERSION})."
+    return 0
+  fi
+
+  if $check_only; then
+    echo "Update available: v${VERSION} -> v${remote_version}"
+    return 0
+  fi
+
+  echo "Updating stemplin: v${VERSION} -> v${remote_version}..."
+
+  # Determine install paths (same as install.sh)
+  local bin_dir="$HOME/bin"
+  local skill_dir="$HOME/.claude/skills"
+  local completion_dir="${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions}"
+
+  # 1. Binary — already downloaded, mv for atomic replace
+  mkdir -p "$bin_dir"
+  chmod +x "$tmp"
+  mv "$tmp" "$bin_dir/stemplin"
+
+  # 2. Claude skill
+  mkdir -p "$skill_dir"
+  curl -sSL "$REPO_RAW/skill/stemplin-api.md" -o "$skill_dir/stemplin-api.md" || echo "Warning: failed to update skill file"
+
+  # 3. Bash completions
+  mkdir -p "$completion_dir"
+  curl -sSL "$REPO_RAW/completions/stemplin.bash" -o "$completion_dir/stemplin" || echo "Warning: failed to update completions"
+
+  echo "Updated to v${remote_version}."
 }
 
 # ---------------------------------------------------------------------------
@@ -614,7 +700,10 @@ EOF
       ;;
     reports)
       cat <<'EOF'
-stemplin reports show           Show time report
+stemplin reports show           Show summary report (totals by project/user)
+stemplin reports detailed       Show detailed report (individual time entries)
+
+Both accept:
   --from YYYY-MM-DD             Start date
   --to YYYY-MM-DD               End date
   --clients IDS                 Comma-separated client IDs
@@ -626,6 +715,12 @@ EOF
     token)
       cat <<'EOF'
 stemplin token regenerate       Generate a new API token (invalidates old one)
+EOF
+      ;;
+    update)
+      cat <<'EOF'
+stemplin update                 Download and install the latest version
+stemplin update --check         Check for updates without installing
 EOF
       ;;
     "")
@@ -642,8 +737,9 @@ Commands:
   tasks   [list|show]           Tasks
   time    [list|show|create|update|delete|timer]
   users   [list|show|me]        Users
-  reports [show]                Reports
+  reports [show|detailed]       Reports
   token   [regenerate]          API token management
+  update  [--check]             Update to latest version
   help    [command]             Show help
 
 Global flags:
@@ -693,6 +789,7 @@ case "$command" in
   users)    cmd_users "$@" ;;
   reports)  cmd_reports "$@" ;;
   token)    cmd_token "$@" ;;
+  update)   cmd_update "$@" ;;
   help)     cmd_help "$@" ;;
   *)        die "Unknown command: $command. Try: stemplin help" ;;
 esac

--- a/completions/stemplin.bash
+++ b/completions/stemplin.bash
@@ -8,7 +8,7 @@ _stemplin() {
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-  commands="me orgs clients projects tasks time users reports token help"
+  commands="me orgs clients projects tasks time users reports token update help"
 
   # Global flags
   if [[ "$cur" == -* ]]; then
@@ -45,8 +45,9 @@ _stemplin() {
     tasks)    COMPREPLY=($(compgen -W "list show" -- "$cur")) ;;
     time)     COMPREPLY=($(compgen -W "list show create update delete timer" -- "$cur")) ;;
     users)    COMPREPLY=($(compgen -W "list show me" -- "$cur")) ;;
-    reports)  COMPREPLY=($(compgen -W "show" -- "$cur")) ;;
+    reports)  COMPREPLY=($(compgen -W "show detailed" -- "$cur")) ;;
     token)    COMPREPLY=($(compgen -W "regenerate" -- "$cur")) ;;
+    update)   COMPREPLY=($(compgen -W "--check" -- "$cur")) ;;
     help)     COMPREPLY=($(compgen -W "$commands" -- "$cur")) ;;
   esac
 

--- a/test/test_integration.sh
+++ b/test/test_integration.sh
@@ -15,11 +15,12 @@ if [[ -z "$_REAL_URL" ]] || [[ -z "$_REAL_TOKEN" ]] || [[ -z "$_REAL_ORG" ]]; th
   exit 0
 fi
 
-# Restore real env vars and real _api function
+# Restore real _api function and env vars (env vars AFTER source, since
+# sourcing the CLI re-reads ~/.stemplinrc which would overwrite them)
+__TESTING__=1 source "$CLI_PATH"
 export STEMPLIN_URL="$_REAL_URL"
 export STEMPLIN_API_TOKEN="$_REAL_TOKEN"
 export STEMPLIN_ORG_ID="$_REAL_ORG"
-__TESTING__=1 source "$CLI_PATH"
 unset -f _today
 
 # ---------------------------------------------------------------------------
@@ -88,5 +89,10 @@ cmd_clients delete "$client_id" >/dev/null
 _test "integration: reports show"
 output=$(cmd_reports show --from 2020-01-01 --to 2030-12-31)
 assert_contains "Total:" "$output" "reports show has total"
+
+_test "integration: reports detailed"
+output=$(cmd_reports detailed --from 2020-01-01 --to 2030-12-31)
+assert_contains "Total:" "$output" "reports detailed has total"
+assert_contains "Billable:" "$output" "reports detailed has billable"
 
 _print_summary

--- a/test/test_reports.sh
+++ b/test/test_reports.sh
@@ -56,6 +56,113 @@ MOCK_API_RESPONSE='{"total_minutes":480,"total_entries":5,"by_project":[],"by_us
 output=$(cmd_reports show)
 assert_contains '"total_minutes":480' "$output"
 
+# --- reports detailed formatted ---
+_test "reports detailed formatted output"
+reset_mock
+MOCK_API_RESPONSE='{
+  "total_minutes": 480,
+  "total_billable_minutes": 360,
+  "dates": [
+    {
+      "date": "2025-10-15",
+      "time_regs": [
+        {"id":1,"date_worked":"2025-10-15","client_name":"Acme","project_name":"Website","task_name":"Development","notes":"Homepage work","user_name":"Mario","minutes":120,"project_billable":true,"rate":15000,"billed_amount":30000.0},
+        {"id":2,"date_worked":"2025-10-15","client_name":"Acme","project_name":"Website","task_name":"Design","notes":"Logo","user_name":"Alice","minutes":60,"project_billable":true,"rate":15000,"billed_amount":15000.0}
+      ]
+    },
+    {
+      "date": "2025-10-14",
+      "time_regs": [
+        {"id":3,"date_worked":"2025-10-14","client_name":"Beta","project_name":"App","task_name":"Development","notes":"API work","user_name":"Bob","minutes":300,"project_billable":false,"rate":0,"billed_amount":0}
+      ]
+    }
+  ]
+}'
+output=$(cmd_reports detailed)
+_load_mock_state
+assert_contains "Total: 8:00" "$output"
+assert_contains "Billable: 6:00" "$output"
+assert_contains "DATE" "$output"
+assert_contains "CLIENT" "$output"
+assert_contains "PROJECT" "$output"
+assert_contains "TASK" "$output"
+assert_contains "PERSON" "$output"
+assert_contains "HOURS" "$output"
+assert_contains "Acme" "$output"
+assert_contains "Website" "$output"
+assert_contains "Development" "$output"
+assert_contains "Mario" "$output"
+assert_contains "Alice" "$output"
+assert_contains "Bob" "$output"
+assert_contains "2025-10-15" "$output"
+assert_contains "2025-10-14" "$output"
+assert_equals "GET" "$LAST_API_METHOD"
+assert_contains "/reports/detailed" "$LAST_API_PATH"
+
+# --- reports detailed with filters ---
+_test "reports detailed --from --to builds query string"
+reset_mock
+MOCK_API_RESPONSE='{"total_minutes":0,"total_billable_minutes":0,"dates":[]}'
+cmd_reports detailed --from 2025-10-01 --to 2026-03-02 >/dev/null
+_load_mock_state
+assert_contains "/reports/detailed" "$LAST_API_PATH"
+assert_contains "start_date=2025-10-01" "$LAST_API_PATH"
+assert_contains "end_date=2026-03-02" "$LAST_API_PATH"
+
+# --- reports detailed all filter flags ---
+_test "reports detailed all filter flags"
+reset_mock
+MOCK_API_RESPONSE='{"total_minutes":0,"total_billable_minutes":0,"dates":[]}'
+cmd_reports detailed --clients 95 --projects 122 --users 55,54 --tasks 155 >/dev/null
+_load_mock_state
+assert_contains "client_ids=95" "$LAST_API_PATH"
+assert_contains "project_ids=122" "$LAST_API_PATH"
+assert_contains "user_ids=55,54" "$LAST_API_PATH"
+assert_contains "task_ids=155" "$LAST_API_PATH"
+
+# --- reports detailed raw ---
+_test "reports detailed --raw"
+reset_mock
+RAW=true
+MOCK_API_RESPONSE='{"total_minutes":480,"total_billable_minutes":360,"dates":[]}'
+output=$(cmd_reports detailed)
+assert_contains '"total_billable_minutes":360' "$output"
+assert_contains '"dates"' "$output"
+
+# --- reports detailed truncates long notes ---
+_test "reports detailed truncates long notes"
+reset_mock
+MOCK_API_RESPONSE='{
+  "total_minutes": 60,
+  "total_billable_minutes": 60,
+  "dates": [
+    {
+      "date": "2025-10-15",
+      "time_regs": [
+        {"id":1,"date_worked":"2025-10-15","client_name":"Acme","project_name":"Website","task_name":"Dev","notes":"This is a very long note that should be truncated after thirty characters","user_name":"Mario","minutes":60,"project_billable":true,"rate":15000,"billed_amount":15000.0}
+      ]
+    }
+  ]
+}'
+output=$(cmd_reports detailed)
+assert_contains "This is a very long note that ..." "$output"
+assert_not_contains "truncated after thirty characters" "$output"
+
+# --- reports detailed missing billable falls back to 0 ---
+_test "reports detailed missing billable_minutes defaults to 0"
+reset_mock
+MOCK_API_RESPONSE='{"total_minutes":60,"dates":[]}'
+output=$(cmd_reports detailed)
+assert_contains "Billable: 0:00" "$output"
+
+# --- reports detailed empty dates ---
+_test "reports detailed with no entries"
+reset_mock
+MOCK_API_RESPONSE='{"total_minutes":0,"total_billable_minutes":0,"dates":[]}'
+output=$(cmd_reports detailed)
+assert_contains "Total: 0:00" "$output"
+assert_contains "Billable: 0:00" "$output"
+
 # --- reports unknown action ---
 _test "reports unknown action"
 reset_mock

--- a/test/test_update.sh
+++ b/test/test_update.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+# ---------------------------------------------------------------------------
+# Mock curl for update tests
+# ---------------------------------------------------------------------------
+# The real curl is needed by _api (mocked separately), but cmd_update calls
+# curl directly.  We override curl with a function that returns canned
+# responses based on the URL being fetched.
+
+MOCK_REMOTE_VERSION="$VERSION"   # default: same as local (up to date)
+MOCK_CURL_FAIL=false
+
+curl() {
+  if $MOCK_CURL_FAIL; then
+    return 1
+  fi
+
+  local url=""
+  local outfile=""
+  local args=("$@")
+  for ((i = 0; i < ${#args[@]}; i++)); do
+    case "${args[i]}" in
+      -o) outfile="${args[i+1]}"; ((i++)) ;;
+      http*) url="${args[i]}" ;;
+    esac
+  done
+
+  case "$url" in
+    */bin/stemplin)
+      local content='#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="'"$MOCK_REMOTE_VERSION"'"
+'
+      if [[ -n "$outfile" ]]; then
+        echo "$content" > "$outfile"
+      else
+        echo "$content"
+      fi
+      ;;
+    */skill/stemplin-api.md)
+      if [[ -n "$outfile" ]]; then
+        echo "# mock skill" > "$outfile"
+      fi
+      ;;
+    */completions/stemplin.bash)
+      if [[ -n "$outfile" ]]; then
+        echo "# mock completions" > "$outfile"
+      fi
+      ;;
+    *)
+      echo "mock curl: unexpected URL: $url" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Override mkdir/chmod/mv to avoid filesystem side effects
+_UPDATE_LOG=""
+mkdir() { _UPDATE_LOG="${_UPDATE_LOG}mkdir $*; "; }
+chmod() { _UPDATE_LOG="${_UPDATE_LOG}chmod $*; "; }
+mv() { _UPDATE_LOG="${_UPDATE_LOG}mv $*; "; }
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# --- Already up to date ---
+_test "update: already up to date"
+MOCK_REMOTE_VERSION="$VERSION"
+output=$(cmd_update 2>&1)
+assert_contains "Already up to date" "$output"
+assert_contains "v${VERSION}" "$output"
+
+# --- --check with no update ---
+_test "update --check: no update available"
+MOCK_REMOTE_VERSION="$VERSION"
+output=$(cmd_update --check 2>&1)
+assert_contains "Already up to date" "$output"
+
+# --- --check with update available ---
+_test "update --check: update available"
+MOCK_REMOTE_VERSION="9.9.9"
+output=$(cmd_update --check 2>&1)
+assert_contains "Update available" "$output"
+assert_contains "v${VERSION}" "$output"
+assert_contains "v9.9.9" "$output"
+
+# --- Successful update ---
+_test "update: successful update"
+MOCK_REMOTE_VERSION="9.9.9"
+_UPDATE_LOG=""
+output=$(cmd_update 2>&1)
+assert_contains "Updating stemplin" "$output"
+assert_contains "v${VERSION} -> v9.9.9" "$output"
+assert_contains "Updated to v9.9.9" "$output"
+
+# --- curl failure ---
+_test "update: curl failure"
+MOCK_CURL_FAIL=true
+output=$(cmd_update 2>&1) && rc=0 || rc=$?
+assert_equals "1" "$rc"
+assert_contains "Failed to download" "$output"
+MOCK_CURL_FAIL=false
+
+# --- Unknown flag ---
+_test "update: unknown flag"
+output=$(cmd_update --bogus 2>&1) && rc=0 || rc=$?
+assert_equals "1" "$rc"
+assert_contains "Unknown flag" "$output"
+
+# --- Help topic ---
+_test "help update shows usage"
+output=$(cmd_help update)
+assert_contains "stemplin update" "$output"
+assert_contains "--check" "$output"
+
+_print_summary


### PR DESCRIPTION
## Summary

- Add `stemplin update` command that downloads the latest version from GitHub and replaces the binary, skill, and completions files in-place (atomic via `mktemp` + `mv`)
- Add `stemplin update --check` to check for updates without installing
- Add `stemplin reports detailed` subcommand showing per-entry breakdown with dates, clients, projects, tasks, users, hours, and notes
- Extract shared `_build_report_qs` helper for report flag parsing
- Add bash completions for both new commands

## Test plan

- [x] 15 new unit tests for `cmd_update` (mocked curl): already up to date, `--check`, successful update, curl failure, unknown flag, help topic
- [x] 30 new unit tests for `reports detailed`: formatted output, filters, raw mode, note truncation, empty dates
- [x] Full suite passes: 280 tests, 0 failures
- [ ] Manual: `stemplin update --check` shows current vs latest
- [ ] Manual: `stemplin update` updates in-place, `stemplin --version` confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)